### PR TITLE
MailGun not always being found

### DIFF
--- a/content.js
+++ b/content.js
@@ -136,7 +136,7 @@ window.addEventListener("message", function(event) {
 		}
 		
 		// Mailgun
-		if( rawEmail.match(/^X-Mailgun-Sid:/m) ) {
+		if( rawEmail.match(/^X-Mailgun-Sid:/m) || rawEmail.match(/X-Mailgun-Variables:/m) ) {
 			service = {name: "Mailgun", url: "https://www.mailgun.com/"};
 		}
 


### PR DESCRIPTION
I got a newsletter from a MailGun user today which didn't identify MG. Maybe MailGun newsletters don't have X-Mailgun-Sid, so watch for X-Mailgun-Variables as well?
