### PR TITLE
Add compatibility for new Gmail redesign

### DIFF
--- a/content.js
+++ b/content.js
@@ -6,11 +6,12 @@ function documentInformationAgent () {
 				setTimeout(EICheck, 500);
 			}else{
 				var locationInfo = location.href.match(/\/(\w+?)$/);
-				
-				if(locationInfo && locationInfo[1]){
+				var threadIdElement = document.querySelector("h2[data-legacy-thread-id]")
+
+				if(threadIdElement && threadIdElement.dataset){
 
 					var auth = window.GLOBALS[9],
-						emailId = locationInfo[1];
+							threadId = threadIdElement.dataset.legacyThreadId
 
 					window.EIxhr = new XMLHttpRequest();
 					EIxhr.onreadystatechange = function () {
@@ -19,18 +20,18 @@ function documentInformationAgent () {
 						}
 					};
 
-					EIxhr.open("GET", document.location.origin + document.location.pathname + "?view=om&ui=2&ik=" + auth + "&th=" + emailId, true);
+					EIxhr.open("GET", document.location.origin + document.location.pathname + "?view=om&ui=2&ik=" + auth + "&th=" + threadId, true);
+
 					EIxhr.send();
-					
 				}
 			}
 		} catch (e) {}
 	}
-	
+
 	window.onpopstate = EICheck;
 
 	// A bad way to try to check on initial page load
-	document.onload = setTimeout(EICheck, 2000);
+	document.onload = setTimeout(EICheck, 3000);
 }
 
 // Inject Information Agent
@@ -39,14 +40,13 @@ informationAgentScript.appendChild(document.createTextNode('('+ documentInformat
 (document.body || document.head || document.documentElement).appendChild(informationAgentScript);
 
 window.addEventListener("message", function(event) {
-	
+
 	// Only accept messages from the window
 	if (event.source != window)
 		return;
 
 	// Make sure it's the right message
 	if (event.data.type && (event.data.type == "ei-mail-raw")) {
-
 		var rawEmail = event.data.raw,
 			service = {};
 
@@ -91,7 +91,7 @@ window.addEventListener("message", function(event) {
 		}
 
 		// ExactTarget
-		if( rawEmail.match(/^x-job: \d{3,}_\d{3,}$/m) && rawEmail.match(/mta[\d]*\.[\w-\.]+\.[a-z]{2,}/i) ) { // Two checks as x-job is not proprietary 
+		if( rawEmail.match(/^x-job: \d{3,}_\d{3,}$/m) && rawEmail.match(/mta[\d]*\.[\w-\.]+\.[a-z]{2,}/i) ) { // Two checks as x-job is not proprietary
 			service = {name: "ExactTarget", url: "http://www.exacttarget.com/"};
 		}
 
@@ -129,12 +129,12 @@ window.addEventListener("message", function(event) {
 		if( rawEmail.match(/^X-MC-User:/m) ) {
 			service = {name: "MailChimp", url: "https://mailchimp.com/"};
 		}
-		
+
 		// MailerLite
 		if( rawEmail.match(/d=ml.mailersend.com;/) ) {
 			service = {name: "MailerLite", url: "https://www.mailerlite.com/"};
 		}
-		
+
 		// Mailgun
 		if( rawEmail.match(/^X-Mailgun-Sid:/m) ) {
 			service = {name: "Mailgun", url: "https://www.mailgun.com/"};
@@ -221,6 +221,7 @@ window.addEventListener("message", function(event) {
 
 			// Attempt to find the place to put the icon in the gmail interface
 			var has = document.getElementsByClassName("ha");
+
 			for (var i = has.length - 1; i >= 0; i--) {
 				if(has[i].getElementsByTagName("span")){
 
@@ -235,9 +236,11 @@ window.addEventListener("message", function(event) {
 					serviceIcon.setAttribute("style", "top:1px");
 
 					serviceLink.appendChild(serviceIcon);
-					
-					has[i].getElementsByTagName("span")[0].appendChild(serviceLink);
-					return;
+
+
+					has[i].getElementsByTagName("span")[0].insertAdjacentElement("afterend", serviceLink);
+
+					return false;
 				}
 			}
 		}

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Email Intelligence",
   "description": "Email Intelligence displays which email infrastructure provider sent an email to your gmail account.",
-  "version": "1.0.6",
+  "version": "1.0.7",
 
   "content_scripts": [
       {


### PR DESCRIPTION
Gmail redesign caused issues with pulling the email ID and subsequently accessing the raw email source. Location slug no longer corresponds to the email ID. The email ID or thread ID seems to be accessed by a number of other plugins from the `h2[data-legacy-thread-id]` element so this update pulls from that element as it's present in both new and classic Gmail.

ServiceLink is also now inserted as an adjacent element to the span as the new redesign was repainting that element after the service link was being added.